### PR TITLE
feat: sync actions into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,26 @@ To run a specific test, run
 ```
 docker-compose run --rm tests py.test -k my_test
 ```
+
+## Actions
+
+### list
+
+`list` action returns a list of projects and datasets in this format
+
+```json
+{
+    "projects": [
+        {
+            "id": "bigquery-writer-158018",
+            "name": "BigQuery Writer",
+            "datasets": [
+                {
+                    "id": "travis_test",
+                    "name": "travis_test"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/google_bigquery_writer/app.py
+++ b/google_bigquery_writer/app.py
@@ -62,12 +62,6 @@ class App:
         if action == 'run' or action is None or action == '':
             self.action_run()
             return
-        if action == 'listProjects':
-            self.action_list_projects()
-            return
-        if action == 'listDatasets':
-            self.action_list_datasets()
-            return
         if action == 'list':
             self.action_list()
             return

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -248,4 +248,3 @@ class TestApp(GoogleBigQueryWriterTest):
             lambda dataset: dataset['id'],
             project['datasets']
         )
-


### PR DESCRIPTION
Místo sync akcí `listProjects` a `listDatasets` bude jen `list`, která vypíše všechno z předchozích dvou akcí. Je úplně zbytečný to v UI nějak komplikovat dvěma akcema, když to jde načíst jednou (podobně jako db extraktory).