### PR TITLE
feat: update bigquery client to 1.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.6
 RUN pip install --no-cache-dir --ignore-installed \
 		pytest \
         pytest-cov \
-        google-cloud-bigquery==1.4.0 \
+        google-cloud-bigquery==1.23.0 \
         oauth2client \
         coverage==4.5.1 \
         flake8


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SRE-291

travis updatnu jak se rozběhne (potřebuje nový oauth credentials), má teď maintenance

edit: na travisu zeleno, je to good to go