### PR TITLE
fix: Use correct temp path

### DIFF
--- a/google_bigquery_writer/writer.py
+++ b/google_bigquery_writer/writer.py
@@ -24,7 +24,7 @@ class Writer(object):
     REQUEST_TIMEOUT = 120  # Timeout in seconds
     DEFAULT_CHUNK_SIZE_MB = 1_000
     MAX_WORKERS = 5  # https://cloud.google.com/bigquery/quotas#standard_tables
-    TEMP_PATH = '/home/data/temp'
+    TEMP_PATH = '/tmp/data'
 
     def __init__(self, bigquery_client: bigquery.Client):
         self.bigquery_client = bigquery_client


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C054DF696LD/p1742569030297299

If any component needs to put some temporary data on disk, it must always use `/tmp`, where large data disk is mounted on GCP. Anything outside `/data` and `/tmp` lives on system disk on a node, which has limited capacity.